### PR TITLE
Fix documentation for map.keys().

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ m.values(); // ['x', 'y']
 m.count() === 2;
 ```
 
-## map.values():Array
+## map.keys():Array
 
 Returns an array containing the key of each item in the map.
 
@@ -252,7 +252,7 @@ Example:
 var m = new OrderedHashMap();
 m.set('a', 'x');
 m.set('b', 'y');
-m.values(); // ['a', 'b']
+m.keys(); // ['a', 'b']
 m.count() === 2;
 ```
 


### PR DESCRIPTION
Fixed documentation to accurately describe the map.keys() method. Small typos existed that referred to map.values() instead.
