### PR TITLE
Update map.forEach() to include index in callback, with tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,13 @@ m.count() === 2;
 
 ## map.forEach(callback:Function)
 
-Invokes the given callback function for each item in the map.
+Invokes the given callback function for each item in the map, in order.
 
 The callback function will be passed the following arguments for each item in the map:
 
  * the value of the item
  * the key of the item
+ * the index of the item
  * the map itself
 
 Example:
@@ -272,13 +273,13 @@ Example:
 var m = new OrderedHashMap();
 m.set('x', 1);
 m.set('y', 2);
-m.forEach(function (v, k) {
-  console.log(k, '->', v);
+m.forEach(function (v, k, i) {
+  console.log(i, ')', k, '->', v);
 });
 /*
 Console output:
- x -> 1
- y -> 2
+ 0 ) x -> 1
+ 1 ) y -> 2
 */
 ```
 

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ OrderedHashMap.prototype.keys = function () {
 OrderedHashMap.prototype.forEach = function (fn) {
   for (var i = 0; i < this._order.length; i++) {
     var hash = this._order[i];
-    fn(this._values[hash], this._keys[hash], this);
+    fn(this._values[hash], this._keys[hash], i, this);
   }
 };
 OrderedHashMap.prototype.map = function (fn) {

--- a/test/ordered-hashmap.js
+++ b/test/ordered-hashmap.js
@@ -79,6 +79,19 @@ describe('OrderedHashMap.fromTuples', function () {
   });
 });
 
+describe('OrderedHashMap.forEach', function () {
+  it('iterates over all items', function () {
+    var vals = [['x', 'a'], ['y', 'b'], ['z', 'c']];
+    var m = OrderedHashMap.fromTuples(vals);
+    var expected = ['ax0', 'by1', 'cz2',];
+    var result;
+    m.forEach(function(val, key, index){
+      result = val + key + index.toString();
+      expect( result ).to.equal( expected[index] );
+    })
+  });
+});
+
 describe('OrderedHashMap::_hash', function () {
   var hash = OrderedHashMap.prototype._hash;
   it('is a function', function () {


### PR DESCRIPTION
Updated the map.forEach method to also include the index in the callback. Of the several pull requests submitted this is the only one with any potential breaking changes.

I updated the callback arguments from (value, key, map) to (value, key, index, map)... Therefore it's possible for someone who has implemented this library to be using the 'map' object in the callback, which would now instead pass the index value. 

The index value in the forEach callback is a useful addition and it seemed fitting to be placed after the key and before the actual map object itself. However, that is something to consider for this pull request.

Cheers!
